### PR TITLE
Updating to work with turbolinking and remove console errors.

### DIFF
--- a/app/assets/javascripts/map.coffee
+++ b/app/assets/javascripts/map.coffee
@@ -1,23 +1,30 @@
 map = undefined
 geocoder = undefined
 
-$(document).ready ->
-  #Declare variables/arrays etc
-  mapOptions = 
-    zoom: 14
-    center:
-      lat: -34.397
-      lng: 150.644
-  map = new (google.maps.Map)(document.getElementById('map-canvas'), mapOptions)
-  geocoder = new (google.maps.Geocoder)
+# Moved into one ready function to be called across page load and document.ready as discussed on Slack
+ready = ->
+  # To remove the console error, I'm only running this on the maps page
+  loc = window.location.pathname
+  console.log loc
+  if loc.includes('map')
+    #Declare variables/arrays etc
+    mapOptions = 
+      zoom: 14
+      center:
+        lat: -34.397
+        lng: 150.644
+    map = new (google.maps.Map)(document.getElementById('map-canvas'), mapOptions)
+    geocoder = new (google.maps.Geocoder)
+    
+    # Work with submitted address  
+    $('#addr_submit').click ->
+      address = $('#addr_box').val()
+      geocodeAddress geocoder, map, address
+      return
+
   return
 
-$(document).ready ->
-  $('#addr_submit').click ->
-    address = $('#addr_box').val()
-    geocodeAddress geocoder, map, address
-    return
-
+# Convert Address into lat and long and show on map
 geocodeAddress = (geocoder, resultsMap, address) ->
   geocoder.geocode { 'address': address }, (results, status) ->
     if status == google.maps.GeocoderStatus.OK
@@ -29,3 +36,8 @@ geocodeAddress = (geocoder, resultsMap, address) ->
       alert 'Geocode was not successful for the following reason: ' + status
     return
   return
+
+# Turbolinking only runs the $(document).ready on initial page load. 
+# So we need to assign 'ready' to both document.ready and page:load (which is a turboscript thing)
+$(document).ready ready
+$(document).on 'page:load', ready


### PR DESCRIPTION
@slehmann36 @jayden2 

I've modified the map.coffee file to work with the turbolinking issues I found earlier so his code will run on page load and on page change.

I've put in a check for the 'map' url to remove the console errors. We'll probably want to make this better before we deliver.

Cheers,

Daniel
