### PR TITLE
…

### DIFF
--- a/app/assets/javascripts/base/global.coffee
+++ b/app/assets/javascripts/base/global.coffee
@@ -32,6 +32,19 @@ ready = ->
 			0
 		]							# Set the maximum time (5 pm)
 
+	# Dismiss the nearest Semantic message with a close icon
+	$('.message .close').on 'click', ->
+		$(this).closest('.message').transition 'fade'
+		return
+
+	# Show a tooltip popup on all password input/change fields both in the modal and on the devise pages (set the content and width here, either wide or very wide)
+	$('.password-popup').popup
+		on: 'focus'
+		inline: true
+		exclusive: true
+		variation: 'very wide'
+		content: 'Your password must be at least 8 characters long and include: 1 capital letter, 1 lowercase letter and either 1 symbol or 1 number.'
+	
 	return
 
 # Turbolinking only runs the $(document).ready on initial page load. 

--- a/app/assets/javascripts/base/user_login.coffee
+++ b/app/assets/javascripts/base/user_login.coffee
@@ -24,15 +24,6 @@ ready = ->
 	# 	profile = googleUser.getBasicProfile()
 	# 	console.log('Full Name: ' + profile.getName())
 	# 	return
-	
-	# Show a tooltip popup on all password input/change fields both in the modal and on the devise pages (set the content and width here, either wide or very wide)
-	$('.password-popup').popup
-		on: 'focus'
-		inline: true
-		exclusive: true
-		variation: 'very wide'
-		content: 'Your password must be at least 8 characters long and include: 1 capital letter, 1 lowercase letter and either 1 symbol or 1 number.'
-	
 
 	# Set up and show the modal
 	# Set callbacks and launch the modal
@@ -99,14 +90,9 @@ ready = ->
 		# Set callback actions and show it
 		user_modal.modal(
 			onHide: ->
-				console.log 'Model being closed'
 				# Clear the input fields when it's closed
-				user_modal.find('#user-email-input').val("")
-				user_modal.find('#user-password-input').val("")
-				user_modal.find('#user-confirm-password-input').val("")
-			onApprove: ->
-				console.log 'Submit was hit'
-
+				user_modal.find('#user-sign-up-form .field input').val("")
+				user_modal.find('#user-login-form .field input').val("")
 		).modal 'show'
 
 		

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,6 +28,9 @@ class ApplicationController < ActionController::Base
 
 	# Go to the previous url or the root_path after logging out of the site. (aka the site where the request to logout came from)
 	def after_sign_out_path_for(resource)
-		request.referrer
+		# Get the controller of the requesting route
+		requesting_route_controller = Rails.application.routes.recognize_path(request.referrer)[:controller]
+		# Go back to the refering request on logout unless it was a dashboard site (as the user has logged out) in which case go to root_path.
+		requesting_route_controller != "dashboard" ? request.referrer : root_path
 	end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,22 @@
+#   Creator: Daniel Swain
+#   Date created: 29/04/2016
+#   
+#   This controller overrides the after_sign_up_path_for method from the inbuilt Devise Registrations Controller
+#   This will redirect the user to the dashboard_settings page on successfull sign-up
+# 	
+
+class RegistrationsController < Devise::RegistrationsController
+	protected
+
+	# Redirect to the dashboard settings page after successful sign up
+	# This method takes a path 'path/to/url' or a path helper symbol.
+	def after_sign_up_path_for(resource)
+		# The user has just signed up so lets send a message (this will dissapear after a page refresh or redirect)
+		flash[:just_signed_up] = "Welcome to Propertydome!"
+		# Redirect using the dashboard_settings path.
+		:dashboard_settings
+	end
+
+	# If we make it so the user is :confirmable then we need to override the following method as well
+	# after_inactive_sign_up_path_for(resource) (using the same method as above)
+end 		

--- a/app/views/dashboard/_settingscontent.html.erb
+++ b/app/views/dashboard/_settingscontent.html.erb
@@ -5,4 +5,23 @@
 #   Partial to display the user settings
 %>
 
+<% # The page header %>
 <h1 class="ui center aligned">Settings</h1>
+
+<% # If the user has just signed up they will be redirected here and will see the following message. This message will only show the first time after sign-up %>
+<% if flash[:just_signed_up] %>
+	<% # A positive message block that is dismissable %>
+	<div class="ui positive message">
+		<% # The close icon %>
+		<i class="close icon"></i>
+		<% # The header text is set in the registrations_controller.rb (see the flash[:just_signed_up] declaration) %>
+		<div class="header">
+			<%= flash[:just_signed_up] %>
+		</div>
+		<% # The message content (in this case, instructions to the user about what they should do next) %>
+		<p>Thanks for signing up! This page is where you can set your username and other personal details.</p>
+		<p>You can also upload a profile picture and set your notification preferences.</p>
+	</div>
+<% end %>
+
+<% # The remaining settings actions to go here %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -50,7 +50,7 @@
 						<% # Confirm Password Field %>
 						<div class="field">
 							<label>Confirm new password</label>
-							<%= f.password_field :password_confirmation, autocomplete: "off", placeholder: "Confirm your new password", class: "password-popup" %>
+							<%= f.password_field :password_confirmation, autocomplete: "off", placeholder: "Confirm your new password" %>
 						</div>
 
 						<% # Devise error messages (only show if they exist) %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -55,7 +55,7 @@
 						<% # Confirm new password field %>
 						<div class="field">
 							<label>Confirm New Password</label>
-							<%= f.password_field :password_confirmation, autocomplete: "off", placeholder: "Confirm your new password", class: "password-popup" %>
+							<%= f.password_field :password_confirmation, autocomplete: "off", placeholder: "Confirm your new password" %>
 						</div>
 						
 						<% # Old Password field %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -50,7 +50,7 @@
 
 						<div class="field">
 							<label>Confirm Password</label>
-							<%= f.password_field :password_confirmation, autocomplete: "off", placeholder: "Confirm your password", class: "password-popup" %>
+							<%= f.password_field :password_confirmation, autocomplete: "off", placeholder: "Confirm your password" %>
 						</div>
 						
 						<%= devise_error_messages! %>

--- a/app/views/layouts/_user_modal.html.erb
+++ b/app/views/layouts/_user_modal.html.erb
@@ -11,9 +11,6 @@
 #   	If you want to make changes to the above two items then do it via the javascript.
 #
 #   Todo:
-#   	* Form field validation
-#   	* Connect to the actual user signup and login actions
-#   	* Change forgotten password link to point to correct action. Currently points to buy_path
 %>
 
 <% # The status modal %>
@@ -103,7 +100,7 @@
 								<% # User sign up confirm password %>
 								<div class="field">
 									<label>Confirm Password</label>
-									<%= f.password_field :password_confirmation, autocomplete: "off", placeholder: "Confirm your password", class: "password-popup" %>
+									<%= f.password_field :password_confirmation, autocomplete: "off", placeholder: "Confirm your password" %>
 								</div>
 								
 								<% # Devise error messages (only show if they exist) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   # Devise configuration (note, setting path to '' means we don't have /users/sign_up it will be /sign_up)
   # Also, changing the sign_in and edit paths to /login and /edit_account
-  devise_for :users, path: '', path_names: { sign_in: 'login', edit: 'edit_account' }
+  devise_for :users, path: '', path_names: { sign_in: 'login', edit: 'edit_account' }, controllers: { registrations: "registrations" }
 
   # Root URL maps to the buy controller root action which redirects to the index action
   root 'buy#root'


### PR DESCRIPTION
Simon, did a bit of work with Devise and our login/sign-up flow. 

Here's the summary:
- Moving .password-popup javascript from user_login.coffee to global.coffee as it's for multiple pages with password fields so it felt more useful to be in global.coffee.
- Adding message close functionality to global.coffee (clicking the close button on any semantic-ui message will close only that message).
- Updated the redirect after logout action to return to the requesting page only if it isn't the user dashboard (in that case go to the root url).
- Updated devise views and user_modal to remove password popup class on confirm password field.
- Updated user_modal to clear input fields on close/dismiss (done in user_login.coffee).
- Added custom registration controller that redirects the user after a successful registration (sign-up) and declared this to devise in the routes file.
- The redirection to the dashboard/settings path on sign-up will show the following message the first (and only time it happens). This message won't be displayed again (from the registration controller), but we can probably set it to come up every now and again later if they haven't updated anything.

![screen shot 2016-04-29 at 12 22 46](https://cloud.githubusercontent.com/assets/3234134/14908364/d3ebbadc-0e08-11e6-901f-1846e4c3265c.png)

Cheers,

Daniel
