### PR TITLE
Sell pages - Fixes and addition of listing tags and features to manage listing cards.

### DIFF
--- a/app/assets/stylesheets/pages/_sell.sass
+++ b/app/assets/stylesheets/pages/_sell.sass
@@ -9,6 +9,7 @@
 	color: $red-primary !important
 
 // Buttons & Ribbon
+.sell-red,
 .sell-red-button,
 .sell-red-ribbon
 	background-color: $red-primary !important
@@ -97,20 +98,32 @@
 		color: $white-primary
 
 // Remove margin right on icons in property feature elements on manage page
-.sell-listing-feature .icon
-	margin-right: 0px
+// Size the icon and text together to ensure they match.
+.sell-listing-feature 
+	font-size: 1.2em
+	.icon
+		margin-right: 0px
 	
-// Send element to bottom of container (were all rem's)
+// Send element to bottom of container
 .manage-property-bottom
 	position: absolute
 	bottom: 1em
 	left: 1em
 	span
 		padding-right: 1em
+	// The top row for the tags (situated in the bottom row) giving it some bottom padding to better separate it from
+	// the view, favourite, comment counts. Also add margin-bottom to the labels in this row incase they wrap around on smaller screens
+	.top-row
+		margin-bottom: 1em
+		.label
+			margin-bottom: 0.5em
 .manage-property-bottom-right
 	position: absolute
 	bottom: 1em
 	right: 1em
+	// Fix the border radius not showing on the left side of the delete button
+	.button
+		border-radius: 0.28em !important
 
 // Override the colour of the pagination class links so they can be seen
 .pagination a

--- a/app/helpers/sell_helper.rb
+++ b/app/helpers/sell_helper.rb
@@ -103,8 +103,8 @@ module SellHelper
 		readable_tags = []
 		# Convert each tag to a readable version
 		# An option tag requires formmating like follows ["Text", "Value"] and we want [ "Qty Label", "qty_label_category" ]
-		# So we need to conver the @tags into an array with the formmating above
-		@tags.each do |tag|
+		# So we need to conver the tags into an array with the formmating above
+		tags.each do |tag|
 			# Get the tag_label, which we refer to as qty
 			qty = tag.tag_label
 			# Get the tag type from the TagType database using the tag_type_id stored with the tag, we need this for the Label and Category
@@ -118,5 +118,4 @@ module SellHelper
 		# Return the formatted tags array list
 		return readable_tags
 	end
-
 end

--- a/app/views/sell/_manage_property_card.html.erb
+++ b/app/views/sell/_manage_property_card.html.erb
@@ -7,11 +7,12 @@
 #   This represents a property that will be manigable by the user, it might be rendered multiple times
 #   
 #   Collections
-#   	@listings: The collection of listing objects from the database. Access properties using the database column names as listed in /app/models/listing.rb
+#   	@listings: The collection of listing objects from the database. 
+#   		Access properties using the database column names as listed in /app/models/listing.rb
 #   
 #   Todo:
-#   	* Prompt/Dialog/Modal for the delete button
-#   	* Style the property features (beds/baths...)
+#   	* Style the Prompt/Dialog/Modal for the delete button
+#   	* Change the bathroom count icon from a bed to a bath when Jayden designs it.
 %>
 
 <% # A property listing management card. %>
@@ -77,41 +78,71 @@
 					<% # Description and information block %>
 					<div class="nine wide column">
 						<% # The Description %>
-						<p><b>Description: </b><%= listing.listing_description %></p>
-
-						<% # The bottom info bar showing views, comments, favourites and expiry %>
+						<div class="row">
+							<b>Description: </b><%= listing.listing_description %>
+						</div>
+						
+						<% # The bottom info bar showing a tag row, and a row of views, comments, favourites and expiry %>
 						<div class="manage-property-bottom">
-							<% # The number of views %>
-							<span>
-								<%= content_tag(:i, "", class:"unhide icon") %>
-								<%= listing.listing_views %> Views
-							</span>
-							<% # The number of favourites %>
-							<span>
-								<%= content_tag(:i, "", class:"star icon") %>
-								<%= listing.listing_favourites %> Favourites
-							</span>
-							<% # The number of comments %>
-							<span>
-								<%= content_tag(:i, "", class:"comments icon") %>
-								<%= listing.listing_comments %> Comments
-							</span>
-							<% # The time left until expiry %>
-							<% # TODO make this get from database %>
-							<span>
-								<%= content_tag(:i, "", class:"wait icon") %>
-								6 Weeks Until Expired
-							</span>
+							<% # The row of feature tags (only showing the first 10) %>
+							<% if listing.listing_tags.size > 0  %>
+								<% # We have tags, so lets get the readable collection and display them %>
+								<div class="row top-row">
+									<% # Get the tag list in a readable format (this returns a 2d array, but we only need the first element) %>
+									<% tags = add_edit_get_readable_tags_collection(listing.listing_tags) %>
+									<% # A label for each tag in the list %>
+									<% tags.each do |tag| %>
+										<div class="ui sell-red label">
+											<% # tag[0] = "Value Tag_Label", tag[1] = "value_tag-label_tag-category" %>
+											<%= tag[0] %>
+										</div>
+									<% end %>
+								</div>
+							<% end %>
+							
+							<% # The Row of views, comments, favourites and expiry date %>
+							<div class="row">
+								<% # The number of views %>
+								<span>
+									<%= content_tag(:i, "", class:"unhide icon") %>
+									<%= listing.listing_views %> Views
+								</span>
+								<% # The number of favourites %>
+								<span>
+									<%= content_tag(:i, "", class:"star icon") %>
+									<%= listing.listing_favourites %> Favourites
+								</span>
+								<% # The number of comments %>
+								<span>
+									<%= content_tag(:i, "", class:"comments icon") %>
+									<%= listing.listing_comments %> Comments
+								</span>
+								<% # The time left until expiry %>
+								<% # TODO make this get from database %>
+								<span>
+									<%= content_tag(:i, "", class:"wait icon") %>
+									6 Weeks Until Expired
+								</span>
+							</div>
 						</div>
 					</div>
 					
 					<% # Features and Delete Button block %>
 					<div class="three wide right aligned column">
 						<% # Property Listing features %>
+						<% # Get the listing pricy type for display %>
+						<p class="sell-listing-feature">
+							<% if listing.listing_price_type == "F" %>
+								<b><%= number_to_currency(listing.listing_price_min, { precision: 0 }) %></b>
+							<% else %>
+								<b><%= number_to_currency(listing.listing_price_min, { precision: 0 }) %> - <%= number_to_currency(listing.listing_price_max, { precision: 0, unit: "" }) %></b>
+							<% end %>
+						</p>
+						<% # The remaining listing features %>
 	 					<p class="sell-listing-feature"><b><%= listing.listing_land_size %> sqm</b></p>
-	 					<p class="sell-listing-feature"><b><%= listing.listing_bedrooms %></b> <i class="large bed icon"></i></p>
-	 					<p class="sell-listing-feature"><b><%= listing.listing_bathrooms %></b> <i class="large bed icon"></i></p>
-	 					<p class="sell-listing-feature"><b><%= listing.listing_parking %></b> <i class="large car icon"></i></p>
+	 					<p class="sell-listing-feature"><b><%= listing.listing_bedrooms %></b> <i class="bed icon"></i></p>
+	 					<p class="sell-listing-feature"><b><%= listing.listing_bathrooms %></b> <i class="bed icon"></i></p>
+	 					<p class="sell-listing-feature"><b><%= listing.listing_parking %></b> <i class="car icon"></i></p>
 
 						<% # Delete Property Listing button %>
 						<div class="manage-property-bottom-right">

--- a/app/views/sell/manage.html.erb
+++ b/app/views/sell/manage.html.erb
@@ -56,7 +56,7 @@
 			</div>
 		</div>
 	</div>
-	<% # A notices message box used to display alerts when a user has added or updated a property (it's dismissable) %>
+	<% # A Notice or Error message box used to display alerts when a user has added or updated a property (it's dismissable) %>
 	<% if flash[:listing_notice] %>
 		<% # A positive message block that is dismissable %>
 		<div class="ui positive message">
@@ -65,6 +65,17 @@
 			<% # Message content %>
 			<div class="content">
 				<%= flash[:listing_notice] %>
+			</div>
+		</div>
+	<% end %>
+	<% if flash[:listing_error] %>
+		<% # A negative message block that is dismissable %>
+		<div class="ui negative message">
+			<% # The close icon %>
+			<i class="close icon"></i>
+			<% # Message content %>
+			<div class="content">
+				<%= flash[:listing_error] %>
 			</div>
 		</div>
 	<% end %>


### PR DESCRIPTION
Hi Simon, here's the summary of the commits I'm wanting merged. It's pretty much all contained in the sell-page pages.
- Added the listing tags to the manage_listing_card in the manage listings table
- Fixed bug in sell_controller that appeared when saving a listing (or adding a listing) with no tags (it was expecting tags)
- Fixed bug in get_readable_tag helper method (might have a different name) where I was expecting a @tags collection but was passing just a local variable (changed from @tags to tags)
- Updated stylesheets to fix delete button border and handle positioning of listing tags in card and to properly right align the listing features icons (bathrooms, bedrooms ...)
- Added listing price or price range to manage_listing_card
- Move update status modal higher in the screen to support screens with less vertical height (i.e. laptops)
- Added listing_error flash message to controller and manage.html to support sending of flash error notices along with updating the listing_notice flash message to include the address of the property updated or added via that action.
- Left this bullet point in to see if Nichola reads the email 😛 

Cheers,

Daniel
