### PR TITLE
Further tightened Devise security

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,7 @@ class User < ActiveRecord::Base
 	self.table_name = "users"
 	# Include default devise modules. Others available are:
 	# :confirmable, :lockable, :timeoutable and :omniauthable
-	devise :database_authenticatable, :registerable, :confirmable, :recoverable, :rememberable, :trackable, :validatable
+	devise :database_authenticatable, :registerable, :confirmable, :timeoutable, :lockable, :recoverable, :rememberable, :trackable, :validatable
 
 	# Validate the password complexity
 	validate :password_complexity

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -105,7 +105,7 @@ Devise.setup do |config|
   # config.pepper = '6407002d1be6a65d13331b87487d6009769127b55b29877d63b94cd31eb7b52ad99518754b7d10910850b27694184bb523a1ff5bc68b3f95af18a8333024b7ff'
 
   # Send a notification email when the user's password is changed
-  # config.send_password_change_notification = false
+  config.send_password_change_notification = true
 
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
@@ -121,7 +121,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  # config.confirm_within = 3.days
+  config.confirm_within = 14.days
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
@@ -158,13 +158,13 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 12.hours
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.
   # :failed_attempts = Locks an account after a number of failed attempts to sign in.
   # :none            = No lock strategy. You should handle locking by yourself.
-  # config.lock_strategy = :failed_attempts
+  config.lock_strategy = :failed_attempts
 
   # Defines which key will be used when locking and unlocking an account
   # config.unlock_keys = [:email]
@@ -174,17 +174,17 @@ Devise.setup do |config|
   # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # :both  = Enables both strategies
   # :none  = No unlock strategy. You should handle unlocking by yourself.
-  # config.unlock_strategy = :both
+  config.unlock_strategy = :both
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
-  # config.maximum_attempts = 20
+  config.maximum_attempts = 10
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
-  # config.unlock_in = 1.hour
+  config.unlock_in = 1.hour
 
   # Warn on the last attempt before the account is locked.
-  # config.last_attempt_warning = true
+  config.last_attempt_warning = true
 
   # ==> Configuration for :recoverable
   #

--- a/db/migrate/20160506141127_add_lockable_to_devise.rb
+++ b/db/migrate/20160506141127_add_lockable_to_devise.rb
@@ -1,0 +1,8 @@
+class AddLockableToDevise < ActiveRecord::Migration
+  def change
+    ## Lockable
+    add_column :users, :failed_attempts, :integer, default: 0
+    add_column :users, :unlock_token, :string # Only if unlock strategy is :email or :both
+    add_column :users, :locked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160506110519) do
+ActiveRecord::Schema.define(version: 20160506141127) do
 
   create_table "blockages", primary_key: "blockage_id", force: :cascade do |t|
     t.integer  "blockage_to_user_id",   limit: 4, null: false
@@ -140,6 +140,9 @@ ActiveRecord::Schema.define(version: 20160506110519) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string   "unconfirmed_email",      limit: 255
+    t.integer  "failed_attempts",        limit: 4,   default: 0
+    t.string   "unlock_token",           limit: 255
+    t.datetime "locked_at"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree


### PR DESCRIPTION
- Tightened general Devise security.
- Enabled Devise's :lockable module to lock accounts that exceed the set number of login failures. Accounts are unlock able by either set timeout or automated email unlock.
