### PR TITLE
(MERGE) Favorite button now working on both the property and search page also added the css on property page

### DIFF
--- a/app/assets/stylesheets/pages/_property.sass
+++ b/app/assets/stylesheets/pages/_property.sass
@@ -45,6 +45,24 @@
 			max-width: 1125px
 			height: auto
 	//under image header section
+
+	.fav-property
+		border-color: $transparent
+		i
+			color: $grey-lighter
+		.favd
+			color: $yellow-primary
+	.fav-property:hover
+		border-color: $transparent
+		i
+			color: $grey-light
+			cursor: pointer !important
+		.favd
+			color: $yellow-hover
+
+
+
+
 	.property-details-section
 		margin-top: 11px !important
 		//property inforleft column

--- a/app/views/property/_propertyHeaderImage.html.erb
+++ b/app/views/property/_propertyHeaderImage.html.erb
@@ -1,6 +1,25 @@
 <div class="ui fluid image">
 	<%# Favourite Star %>
-	<a class="ui left corner label fav-property" data-id="<% @listing.listing_id %>"><i class="star icon"></i></a>
+
+	<% if controller_name == "property" %>
+		<%# If we have a current user, then use the check_if_listing_favourited_by_user Application
+		helper function to check if that listing is favd already and if so lets set the button as favd
+		from the get go %>
+		
+		<% if current_user %>
+			<% if check_if_listing_favourited_by_user(@listing.listing_id, current_user.id) %>
+				<a class="ui left corner label fav-property" data-id="<%= @listing.listing_id %>"><i class="star icon favd"></i></a>
+			<% else %>
+				<a class="ui left corner label fav-property" data-id="<%= @listing.listing_id %>"><i class="star icon"></i></a>
+			<% end %>
+
+			<%# The user isn't logged in, so we're not putting the listing id in the data-id value
+			so the AJAX doesn't run and an alert is sent (current temporary solution) %>
+		<% else %>
+			<a class="ui left corner label fav-property" data-id=""><i class="star icon"></i></a>
+		<% end %>
+	<% end %>
+
 	<%# Status "click here to set a status" means if it doesnt have a stus dont have ribbon %>
 			<% if listing_get_status_readable(@listing) != "Click here to set a status" %>
 				<a class="ui red right ribbon label status-ribbon"><%= listing_get_status_readable(@listing) %></a>


### PR DESCRIPTION
So i added the erb and css needed to get the fav button also working on the property page, it saves the fav image when user clicks the star and if the user has already favorite the property it then takes the property out of the users favorite list when clicked again. so this button now works on both the search and property. sooooo have fun :) Also when the user logs in all property's already favorite by the user show as such from login.
