### PR TITLE
Fixing bug where you weren't able to add any listings if none existed…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
-  remote: https://www.github.com/doabit/semantic-ui-sass
-  revision: ec431aa90c80ed6b86e934ff955daf8037bee713
+  remote: git://github.com/doabit/semantic-ui-sass.git
+  revision: a33a0b1d3cfc3f2f44380394cef7322a2894e397
   specs:
-    semantic-ui-sass (2.1.8.0)
+    semantic-ui-sass (2.2.2.2)
       sass (>= 3.2)
 
 GEM

--- a/app/controllers/sell_controller.rb
+++ b/app/controllers/sell_controller.rb
@@ -129,9 +129,6 @@ class SellController < ApplicationController
 		@status = ListingStatus.create(listing_status_label: "None")
 		@listing.listing_status_id = @status.listing_status_id
 
-		# Store the first image as the cover image (This is replaced below after we've actually got images)
-		@listing.listing_cover_image_id = ListingImage.first.listing_image_id
-
 		# Set the listing_to_end_at date equal to 8 weeks from the creation date
 		# DateTime allows us to add days, so we're adding 8 * 7 days to the date to make the expiry date equal to 8 weeks from today
 		current_date = DateTime.now()
@@ -176,7 +173,7 @@ class SellController < ApplicationController
 			end
 		end
 
-		# --------- Update the cover image to be the first of the images we've just added
+		# --------- Update the cover image to be the first of the images we've just added (if any were added, otherwise it will be NULL)
 		first_image = ListingImage.where(listing_image_listing_id: @listing_id).first
 		if first_image
 			@listing.listing_cover_image_id = first_image.listing_image_id


### PR DESCRIPTION
… due to it trying to grab the first listing image when none existed. This has been removed and the listing_cover_image_id is only assigned after listing images have been created
